### PR TITLE
Fix token service

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,48 @@ func profileHandler(c router.Context) error {
 }
 ```
 
+## API Reference
+
+### TokenService Access
+
+The `Authenticator` provides access to its underlying `TokenService` for advanced use cases:
+
+```go
+// Access the token service directly
+tokenService := authenticator.TokenService()
+
+// Generate tokens manually with custom resource roles
+resourceRoles := map[string]string{
+    "project:123": "admin",
+    "files:uploads": "owner",
+}
+token, err := tokenService.Generate(identity, resourceRoles)
+
+// Validate tokens manually
+claims, err := tokenService.Validate(tokenString)
+```
+
+### JWT Middleware Integration
+
+Use the `TokenService` with JWT middleware for custom authentication flows:
+
+```go
+// Create TokenServiceAdapter for jwtware middleware
+tokenValidator := auth.NewTokenServiceAdapter(authenticator.TokenService())
+
+// Configure JWT middleware
+jwtConfig := jwtware.Config{
+    SigningKey: jwtware.SigningKey{
+        Key:    []byte(config.GetSigningKey()),
+        JWTAlg: config.GetSigningMethod(),
+    },
+    TokenValidator: tokenValidator,
+    ContextKey:     "auth",
+}
+
+middleware := jwtware.New(jwtConfig)
+```
+
 ## Core Concepts
 
 ### User Roles

--- a/authenticator.go
+++ b/authenticator.go
@@ -59,6 +59,11 @@ func (s Auther) WithResourceRoleProvider(provider ResourceRoleProvider) Auther {
 	return s
 }
 
+// TokenService returns the TokenService instance used by this Authenticator
+func (s *Auther) TokenService() TokenService {
+	return s.tokenService
+}
+
 func (s Auther) Login(ctx context.Context, identifier, password string) (string, error) {
 	var err error
 	var identity Identity

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -2,7 +2,6 @@ package auth
 
 import (
 	"context"
-	"mime/multipart"
 	"testing"
 	"time"
 
@@ -247,14 +246,14 @@ func TestGetRouterClaims(t *testing.T) {
 		{
 			name: "should return claims when present with default key",
 			setupFn: func() router.Context {
-				ctx := newMockRouterContext()
-				ctx.Locals("user", &JWTClaims{
+				ctx := router.NewMockContext()
+				ctx.LocalsMock["user"] = &JWTClaims{
 					RegisteredClaims: jwt.RegisteredClaims{
 						Subject: "user123",
 					},
 					UID:      "user123",
 					UserRole: "admin",
-				})
+				}
 				return ctx
 			},
 			key:    "", // Use default key
@@ -263,14 +262,14 @@ func TestGetRouterClaims(t *testing.T) {
 		{
 			name: "should return claims when present with custom key",
 			setupFn: func() router.Context {
-				ctx := newMockRouterContext()
-				ctx.Locals("custom-claims", &JWTClaims{
+				ctx := router.NewMockContext()
+				ctx.LocalsMock["custom-claims"] = &JWTClaims{
 					RegisteredClaims: jwt.RegisteredClaims{
 						Subject: "user123",
 					},
 					UID:      "user123",
 					UserRole: "admin",
-				})
+				}
 				return ctx
 			},
 			key:    "custom-claims",
@@ -279,7 +278,7 @@ func TestGetRouterClaims(t *testing.T) {
 		{
 			name: "should return false when key not present",
 			setupFn: func() router.Context {
-				ctx := newMockRouterContext()
+				ctx := router.NewMockContext()
 				return ctx
 			},
 			key:    "user",
@@ -288,8 +287,8 @@ func TestGetRouterClaims(t *testing.T) {
 		{
 			name: "should return false when value is wrong type",
 			setupFn: func() router.Context {
-				ctx := newMockRouterContext()
-				ctx.Locals("user", "not-a-claims-object")
+				ctx := router.NewMockContext()
+				ctx.LocalsMock["user"] = "not-a-claims-object"
 				return ctx
 			},
 			key:    "user",
@@ -326,14 +325,14 @@ func TestCanFromRouter(t *testing.T) {
 		{
 			name: "should return true when admin can read",
 			setupFn: func() router.Context {
-				ctx := newMockRouterContext()
-				ctx.Locals("user", &JWTClaims{
+				ctx := router.NewMockContext()
+				ctx.LocalsMock["user"] = &JWTClaims{
 					RegisteredClaims: jwt.RegisteredClaims{
 						Subject: "user123",
 					},
 					UID:      "user123",
 					UserRole: "admin",
-				})
+				}
 				return ctx
 			},
 			resource:   "project-123",
@@ -343,14 +342,14 @@ func TestCanFromRouter(t *testing.T) {
 		{
 			name: "should return false when guest cannot create",
 			setupFn: func() router.Context {
-				ctx := newMockRouterContext()
-				ctx.Locals("user", &JWTClaims{
+				ctx := router.NewMockContext()
+				ctx.LocalsMock["user"] = &JWTClaims{
 					RegisteredClaims: jwt.RegisteredClaims{
 						Subject: "user123",
 					},
 					UID:      "user123",
 					UserRole: "guest",
-				})
+				}
 				return ctx
 			},
 			resource:   "project-123",
@@ -360,7 +359,7 @@ func TestCanFromRouter(t *testing.T) {
 		{
 			name: "should return false when no claims in context",
 			setupFn: func() router.Context {
-				ctx := newMockRouterContext()
+				ctx := router.NewMockContext()
 				return ctx
 			},
 			resource:   "project-123",
@@ -407,159 +406,6 @@ func TestWithClaimsContext(t *testing.T) {
 	assert.False(t, retrievedClaims.CanDelete("project-2")) // member cannot delete
 }
 
-// mockRouterContext is a complete test implementation of router.Context
-type mockRouterContext struct {
-	locals map[string]any
-	store  map[string]any
-}
-
-func newMockRouterContext() *mockRouterContext {
-	return &mockRouterContext{
-		locals: make(map[string]any),
-		store:  make(map[string]any),
-	}
-}
-
-// RequestContext interface methods
-func (m *mockRouterContext) Method() string { return "GET" }
-func (m *mockRouterContext) Path() string   { return "/" }
-func (m *mockRouterContext) Param(name string, defaultValue ...string) string {
-	if len(defaultValue) > 0 {
-		return defaultValue[0]
-	}
-	return ""
-}
-func (m *mockRouterContext) ParamsInt(key string, defaultValue int) int { return defaultValue }
-func (m *mockRouterContext) Query(name string, defaultValue ...string) string {
-	if len(defaultValue) > 0 {
-		return defaultValue[0]
-	}
-	return ""
-}
-func (m *mockRouterContext) QueryInt(name string, defaultValue int) int { return defaultValue }
-func (m *mockRouterContext) Queries() map[string]string                 { return nil }
-func (m *mockRouterContext) Body() []byte                               { return nil }
-func (m *mockRouterContext) Locals(key any, value ...any) any {
-	if len(value) > 0 {
-		keyStr := key.(string)
-		m.locals[keyStr] = value[0]
-		return value[0]
-	}
-	keyStr := key.(string)
-	return m.locals[keyStr]
-}
-func (m *mockRouterContext) LocalsMerge(key any, value map[string]any) map[string]any {
-	keyStr := key.(string)
-	existing, exists := m.locals[keyStr]
-
-	if !exists || existing == nil {
-		m.locals[keyStr] = value
-		return value
-	}
-
-	// Try to merge with existing map
-	if existingMap, ok := existing.(map[string]any); ok {
-		merged := make(map[string]any)
-		// Copy existing values
-		for k, v := range existingMap {
-			merged[k] = v
-		}
-		// Merge new values (overwrites existing keys)
-		for k, v := range value {
-			merged[k] = v
-		}
-		m.locals[keyStr] = merged
-		return merged
-	}
-
-	// If existing value is not a map, replace it
-	m.locals[keyStr] = value
-	return value
-}
-func (m *mockRouterContext) Render(name string, bind any, layouts ...string) error { return nil }
-func (m *mockRouterContext) Cookie(cookie *router.Cookie)                          {}
-func (m *mockRouterContext) Cookies(key string, defaultValue ...string) string {
-	if len(defaultValue) > 0 {
-		return defaultValue[0]
-	}
-	return ""
-}
-func (m *mockRouterContext) CookieParser(out any) error                    { return nil }
-func (m *mockRouterContext) Redirect(location string, status ...int) error { return nil }
-func (m *mockRouterContext) RedirectToRoute(routeName string, params router.ViewContext, status ...int) error {
-	return nil
-}
-func (m *mockRouterContext) RedirectBack(fallback string, status ...int) error { return nil }
-func (m *mockRouterContext) Header(key string) string                          { return "" }
-func (m *mockRouterContext) Referer() string                                   { return "" }
-func (m *mockRouterContext) OriginalURL() string                               { return "/" }
-func (m *mockRouterContext) FormFile(key string) (*multipart.FileHeader, error) {
-	return nil, nil
-}
-func (m *mockRouterContext) FormValue(key string, defaultValue ...string) string {
-	if len(defaultValue) > 0 {
-		return defaultValue[0]
-	}
-	return ""
-}
-
-// ResponseWriter interface methods
-func (m *mockRouterContext) Status(code int) router.Context             { return m }
-func (m *mockRouterContext) Send(body []byte) error                     { return nil }
-func (m *mockRouterContext) SendString(body string) error               { return nil }
-func (m *mockRouterContext) SendStatus(code int) error                  { return nil }
-func (m *mockRouterContext) JSON(code int, v any) error                 { return nil }
-func (m *mockRouterContext) NoContent(code int) error                   { return nil }
-func (m *mockRouterContext) SetHeader(key, value string) router.Context { return m }
-
-// ContextStore interface methods
-func (m *mockRouterContext) Set(key string, value any) {
-	m.store[key] = value
-}
-func (m *mockRouterContext) Get(key string, def any) any {
-	if val, exists := m.store[key]; exists {
-		return val
-	}
-	return def
-}
-func (m *mockRouterContext) GetString(key string, def string) string {
-	if val, exists := m.store[key]; exists {
-		if str, ok := val.(string); ok {
-			return str
-		}
-	}
-	return def
-}
-func (m *mockRouterContext) GetInt(key string, def int) int {
-	if val, exists := m.store[key]; exists {
-		if i, ok := val.(int); ok {
-			return i
-		}
-	}
-	return def
-}
-func (m *mockRouterContext) GetBool(key string, def bool) bool {
-	if val, exists := m.store[key]; exists {
-		if b, ok := val.(bool); ok {
-			return b
-		}
-	}
-	return def
-}
-
-// Route Context interface methods
-func (m *mockRouterContext) RouteName() string {
-	return ""
-}
-func (m *mockRouterContext) RouteParams() map[string]string {
-	return nil
-}
-
-// Main Context interface methods
-func (m *mockRouterContext) Bind(v any) error               { return nil }
-func (m *mockRouterContext) Context() context.Context       { return context.Background() }
-func (m *mockRouterContext) SetContext(ctx context.Context) {}
-func (m *mockRouterContext) Next() error                    { return nil }
 
 //--------------------------------------------------------------------------------------
 // Integration Tests for GetClaims and Can Functions

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -448,6 +448,34 @@ func (m *mockRouterContext) Locals(key any, value ...any) any {
 	keyStr := key.(string)
 	return m.locals[keyStr]
 }
+func (m *mockRouterContext) LocalsMerge(key any, value map[string]any) map[string]any {
+	keyStr := key.(string)
+	existing, exists := m.locals[keyStr]
+
+	if !exists || existing == nil {
+		m.locals[keyStr] = value
+		return value
+	}
+
+	// Try to merge with existing map
+	if existingMap, ok := existing.(map[string]any); ok {
+		merged := make(map[string]any)
+		// Copy existing values
+		for k, v := range existingMap {
+			merged[k] = v
+		}
+		// Merge new values (overwrites existing keys)
+		for k, v := range value {
+			merged[k] = v
+		}
+		m.locals[keyStr] = merged
+		return merged
+	}
+
+	// If existing value is not a map, replace it
+	m.locals[keyStr] = value
+	return value
+}
 func (m *mockRouterContext) Render(name string, bind any, layouts ...string) error { return nil }
 func (m *mockRouterContext) Cookie(cookie *router.Cookie)                          {}
 func (m *mockRouterContext) Cookies(key string, defaultValue ...string) string {
@@ -517,6 +545,14 @@ func (m *mockRouterContext) GetBool(key string, def bool) bool {
 		}
 	}
 	return def
+}
+
+// Route Context interface methods
+func (m *mockRouterContext) RouteName() string {
+	return ""
+}
+func (m *mockRouterContext) RouteParams() map[string]string {
+	return nil
 }
 
 // Main Context interface methods

--- a/examples/main.go
+++ b/examples/main.go
@@ -153,7 +153,7 @@ func CreateTemplateAwareJWTMiddleware(app *App, cfg auth.Config) router.Middlewa
 			ContextKey:  cfg.GetContextKey(),
 			TokenLookup: cfg.GetTokenLookup(),
 			// Add TokenValidator - use the authenticator's token service if available
-			TokenValidator: &TokenServiceAdapter{app.auth},
+			TokenValidator: auth.NewTokenServiceAdapter(app.auth.TokenService()),
 			// Template integration - automatic current_user injection
 			TemplateUserKey: auth.TemplateUserKey,
 			UserProvider: func(claims jwtware.AuthClaims) (any, error) {

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/goliatone/go-errors v0.9.0
 	github.com/goliatone/go-print v0.4.1
 	github.com/goliatone/go-repository-bun v0.5.2
-	github.com/goliatone/go-router v0.6.0
+	github.com/goliatone/go-router v0.11.2
 	github.com/goliatone/hashid v0.1.1
 	github.com/google/uuid v1.6.0
 	github.com/nyaruka/phonenumbers v1.5.0
@@ -28,9 +28,11 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dlclark/regexp2 v1.11.5 // indirect
 	github.com/ettle/strcase v0.2.0 // indirect
+	github.com/fasthttp/websocket v1.5.8 // indirect
 	github.com/flosch/pongo2/v6 v6.0.0 // indirect
 	github.com/gertd/go-pluralize v0.2.1 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
+	github.com/gofiber/contrib/websocket v1.3.4 // indirect
 	github.com/gofiber/template v1.8.3 // indirect
 	github.com/gofiber/utils v1.1.0 // indirect
 	github.com/goliatone/go-composite-fs v0.0.1 // indirect
@@ -50,6 +52,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/puzpuzpuz/xsync/v3 v3.5.1 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
+	github.com/savsgio/gotils v0.0.0-20240303185622-093b76447511 // indirect
 	github.com/showa-93/go-mask v0.6.2 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/tmthrgd/go-hex v0.0.0-20190904060850-447a3041c3bc // indirect

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,8 @@ github.com/dlclark/regexp2 v1.11.5 h1:Q/sSnsKerHeCkc/jSTNq1oCm7KiVgUMZRDUoRu0JQZ
 github.com/dlclark/regexp2 v1.11.5/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/ettle/strcase v0.2.0 h1:fGNiVF21fHXpX1niBgk0aROov1LagYsOwV/xqKDKR/Q=
 github.com/ettle/strcase v0.2.0/go.mod h1:DajmHElDSaX76ITe3/VHVyMin4LWSJN5Z909Wp+ED1A=
+github.com/fasthttp/websocket v1.5.8 h1:k5DpirKkftIF/w1R8ZzjSgARJrs54Je9YJK37DL/Ah8=
+github.com/fasthttp/websocket v1.5.8/go.mod h1:d08g8WaT6nnyvg9uMm8K9zMYyDjfKyj3170AtPRuVU0=
 github.com/flosch/pongo2/v6 v6.0.0 h1:lsGru8IAzHgIAw6H2m4PCyleO58I40ow6apih0WprMU=
 github.com/flosch/pongo2/v6 v6.0.0/go.mod h1:CuDpFm47R0uGGE7z13/tTlt1Y6zdxvr2RLT5LJhsHEU=
 github.com/gertd/go-pluralize v0.2.1 h1:M3uASbVjMnTsPb0PNqg+E/24Vwigyo/tvyMTtAlLgiA=
@@ -28,6 +30,8 @@ github.com/go-ozzo/ozzo-validation/v4 v4.3.0 h1:byhDUpfEwjsVQb1vBunvIjh2BHQ9ead5
 github.com/go-ozzo/ozzo-validation/v4 v4.3.0/go.mod h1:2NKgrcHl3z6cJs+3Oo940FPRiTzuqKbvfrL2RxCj6Ew=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
+github.com/gofiber/contrib/websocket v1.3.4 h1:tWeBdbJ8q0WFQXariLN4dBIbGH9KBU75s0s7YXplOSg=
+github.com/gofiber/contrib/websocket v1.3.4/go.mod h1:kTFBPC6YENCnKfKx0BoOFjgXxdz7E85/STdkmZPEmPs=
 github.com/gofiber/fiber/v2 v2.52.6 h1:Rfp+ILPiYSvvVuIPvxrBns+HJp8qGLDnLJawAu27XVI=
 github.com/gofiber/fiber/v2 v2.52.6/go.mod h1:YEcBbO/FB+5M1IZNBP9FO3J9281zgPAreiI1oqg8nDw=
 github.com/gofiber/template v1.8.3 h1:hzHdvMwMo/T2kouz2pPCA0zGiLCeMnoGsQZBTSYgZxc=
@@ -48,8 +52,8 @@ github.com/goliatone/go-print v0.4.1 h1:rRcmZOWd27gq25Ays0nRu09tAH6wgTdfshE4rPpN
 github.com/goliatone/go-print v0.4.1/go.mod h1:hx13/Im2TeOYwwBwj/ImfjneDQ0MyN0ybfrgHripAus=
 github.com/goliatone/go-repository-bun v0.5.2 h1:XZ5oevR9UIGy7gBI/9l3S7JB6BmLA+NduhZWg9oa85w=
 github.com/goliatone/go-repository-bun v0.5.2/go.mod h1:ZG2ZKOpbHhgi81rUtVgdtNCCApu49ihPhHpce4qjaOI=
-github.com/goliatone/go-router v0.6.0 h1:+YNcczkTQ9Zs0qZyYNAg8/G+Fb1yi5/Bm1n7kuD13lw=
-github.com/goliatone/go-router v0.6.0/go.mod h1:1CE170cGlC8UnIzsuxXw4pa7NZcIA6STuP3clIpiOiQ=
+github.com/goliatone/go-router v0.11.2 h1:ISRIe9S9Lp+wnIwFJM8nkHYbi7Gp0ZeCTQvMHEt/Dy4=
+github.com/goliatone/go-router v0.11.2/go.mod h1:Bgl3LturmoBNSGoxEVGYfF6MzeazYyw+5dkRKEObYxs=
 github.com/goliatone/hashid v0.1.1 h1:VfZZf7s0uM+JZ3ZBkqaEM1mL/CJfiTmFOzZ1QuXY3EM=
 github.com/goliatone/hashid v0.1.1/go.mod h1:K9jzegsVvT8S+Nn5wL1AuGVKcz2jcwYMxwe4g1UGz4E=
 github.com/goodsign/monday v1.0.2 h1:k8kRMkCRVfCTWOU4dRfRgneQsWlB1+mJd3MxG0lGLzQ=
@@ -95,6 +99,8 @@ github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
 github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
+github.com/savsgio/gotils v0.0.0-20240303185622-093b76447511 h1:KanIMPX0QdEdB4R3CiimCAbxFrhB3j7h0/OvpYGVQa8=
+github.com/savsgio/gotils v0.0.0-20240303185622-093b76447511/go.mod h1:sM7Mt7uEoCeFSCBM+qBrqvEo+/9vdmj19wzp3yzUhmg=
 github.com/showa-93/go-mask v0.6.2 h1:sJEUQRpbxUoMTfBKey5K9hCg+eSx5KIAZFT7pa1LXbM=
 github.com/showa-93/go-mask v0.6.2/go.mod h1:aswIj007gm0EPAzOGES9ACy1jDm3QT08/LPSClMp410=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/http.go
+++ b/http.go
@@ -16,6 +16,13 @@ type TokenServiceAdapter struct {
 	tokenService TokenService
 }
 
+// NewTokenServiceAdapter creates a new TokenServiceAdapter
+func NewTokenServiceAdapter(tokenService TokenService) *TokenServiceAdapter {
+	return &TokenServiceAdapter{
+		tokenService: tokenService,
+	}
+}
+
 // Validate implements the jwtware.TokenValidator interface
 func (tsa *TokenServiceAdapter) Validate(tokenString string) (jwtware.AuthClaims, error) {
 	return tsa.tokenService.Validate(tokenString)

--- a/middleware/jwtware/jwt.go
+++ b/middleware/jwtware/jwt.go
@@ -119,7 +119,13 @@ func New(config ...Config) router.HandlerFunc {
 				// Use claims directly as template user data
 				templateUser = claims
 			}
-			ctx.Locals(cfg.TemplateUserKey, templateUser)
+
+			// Use LocalsMerge if templateUser is a map[string]any, otherwise use Locals
+			if userMap, ok := templateUser.(map[string]any); ok {
+				ctx.LocalsMerge(cfg.TemplateUserKey, userMap)
+			} else {
+				ctx.Locals(cfg.TemplateUserKey, templateUser)
+			}
 		}
 
 		// if a context enricher we use it to propagate claims to the standard context
@@ -252,6 +258,10 @@ func GetDefaultConfig(config ...Config) (cfg Config) {
 		cfg.LocalTokenSerilizer = func(t *jwt.Token) any {
 			return t
 		}
+	}
+
+	if cfg.TemplateUserKey == "" {
+		cfg.TemplateUserKey = "current_user"
 	}
 
 	return cfg

--- a/middleware/jwtware/jwt_test.go
+++ b/middleware/jwtware/jwt_test.go
@@ -119,6 +119,8 @@ func TestJWTWare_ValidToken(t *testing.T) {
 	ctx.On("Locals", "user", mock.AnythingOfType("*jwtware_test.MockAuthClaims")).Run(func(args mock.Arguments) {
 		storedClaims = args.Get(1).(jwtware.AuthClaims)
 	}).Return(nil)
+	// The middleware also stores user for templates with default key "current_user"
+	ctx.On("Locals", "current_user", mock.AnythingOfType("*jwtware_test.MockAuthClaims")).Return(nil)
 
 	err := middleware(ctx)
 
@@ -241,6 +243,8 @@ func TestJWTWare_TokenLookupVariations(t *testing.T) {
 	ctx.HeadersM["Authorization"] = "Bearer valid-token"
 	ctx.On("GetString", "Authorization", "").Return("Bearer valid-token")
 	ctx.On("Locals", "user", mock.AnythingOfType("*jwtware_test.MockAuthClaims")).Return(nil)
+	// The middleware also stores user for templates with default key "current_user"
+	ctx.On("Locals", "current_user", mock.AnythingOfType("*jwtware_test.MockAuthClaims")).Return(nil)
 
 	err := middleware(ctx)
 
@@ -303,6 +307,8 @@ func TestJWTWare_CustomContextKey(t *testing.T) {
 	ctx.HeadersM["Authorization"] = "Bearer valid-token"
 	ctx.On("GetString", "Authorization", "").Return("Bearer valid-token")
 	ctx.On("Locals", "custom_user", mock.AnythingOfType("*jwtware_test.MockAuthClaims")).Return(nil)
+	// The middleware also stores user for templates with default key "current_user"
+	ctx.On("Locals", "current_user", mock.AnythingOfType("*jwtware_test.MockAuthClaims")).Return(nil)
 
 	err := middleware(ctx)
 
@@ -356,6 +362,8 @@ func TestJWTWare_RequiredRole_Success(t *testing.T) {
 	ctx.HeadersM["Authorization"] = "Bearer valid-admin-token"
 	ctx.On("GetString", "Authorization", "").Return("Bearer valid-admin-token")
 	ctx.On("Locals", "user", mock.AnythingOfType("*jwtware_test.MockAuthClaims")).Return(nil)
+	// The middleware also stores user for templates with default key "current_user"
+	ctx.On("Locals", "current_user", mock.AnythingOfType("*jwtware_test.MockAuthClaims")).Return(nil)
 
 	err := middleware(ctx)
 
@@ -423,6 +431,8 @@ func TestJWTWare_MinimumRole_Success(t *testing.T) {
 	ctx.HeadersM["Authorization"] = "Bearer valid-admin-token"
 	ctx.On("GetString", "Authorization", "").Return("Bearer valid-admin-token")
 	ctx.On("Locals", "user", mock.AnythingOfType("*jwtware_test.MockAuthClaims")).Return(nil)
+	// The middleware also stores user for templates with default key "current_user"
+	ctx.On("Locals", "current_user", mock.AnythingOfType("*jwtware_test.MockAuthClaims")).Return(nil)
 
 	err := middleware(ctx)
 
@@ -496,6 +506,8 @@ func TestJWTWare_CustomRoleChecker_Success(t *testing.T) {
 	ctx.HeadersM["Authorization"] = "Bearer valid-manager-token"
 	ctx.On("GetString", "Authorization", "").Return("Bearer valid-manager-token")
 	ctx.On("Locals", "user", mock.AnythingOfType("*jwtware_test.MockAuthClaims")).Return(nil)
+	// The middleware also stores user for templates with default key "current_user"
+	ctx.On("Locals", "current_user", mock.AnythingOfType("*jwtware_test.MockAuthClaims")).Return(nil)
 
 	err := middleware(ctx)
 
@@ -570,6 +582,8 @@ func TestJWTWare_CustomRoleChecker_OnlyCheck_AccessDenied(t *testing.T) {
 	ctx.HeadersM["Authorization"] = "Bearer valid-guest-token"
 	ctx.On("GetString", "Authorization", "").Return("Bearer valid-guest-token")
 	ctx.On("Locals", "user", mock.AnythingOfType("*jwtware_test.MockAuthClaims")).Return(nil)
+	// The middleware also stores user for templates with default key "current_user"
+	ctx.On("Locals", "current_user", mock.AnythingOfType("*jwtware_test.MockAuthClaims")).Return(nil)
 
 	err := middleware(ctx)
 
@@ -646,6 +660,8 @@ func TestJWTWare_CustomRoleChecker_WithMinimumRole(t *testing.T) {
 	ctx.HeadersM["Authorization"] = "Bearer valid-admin-token"
 	ctx.On("GetString", "Authorization", "").Return("Bearer valid-admin-token")
 	ctx.On("Locals", "user", mock.AnythingOfType("*jwtware_test.MockAuthClaims")).Return(nil)
+	// The middleware also stores user for templates with default key "current_user"
+	ctx.On("Locals", "current_user", mock.AnythingOfType("*jwtware_test.MockAuthClaims")).Return(nil)
 
 	err := middleware(ctx)
 
@@ -680,6 +696,8 @@ func TestJWTWare_NoRBACConfiguration_AllowsAccess(t *testing.T) {
 	ctx.HeadersM["Authorization"] = "Bearer valid-guest-token"
 	ctx.On("GetString", "Authorization", "").Return("Bearer valid-guest-token")
 	ctx.On("Locals", "user", mock.AnythingOfType("*jwtware_test.MockAuthClaims")).Return(nil)
+	// The middleware also stores user for templates with default key "current_user"
+	ctx.On("Locals", "current_user", mock.AnythingOfType("*jwtware_test.MockAuthClaims")).Return(nil)
 
 	err := middleware(ctx)
 
@@ -719,6 +737,8 @@ func TestJWTWare_MultipleRoleRequirements(t *testing.T) {
 	ctx.HeadersM["Authorization"] = "Bearer valid-admin-token"
 	ctx.On("GetString", "Authorization", "").Return("Bearer valid-admin-token")
 	ctx.On("Locals", "user", mock.AnythingOfType("*jwtware_test.MockAuthClaims")).Return(nil)
+	// The middleware also stores user for templates with default key "current_user"
+	ctx.On("Locals", "current_user", mock.AnythingOfType("*jwtware_test.MockAuthClaims")).Return(nil)
 
 	err := middleware(ctx)
 
@@ -767,6 +787,8 @@ func TestJWTWare_ContextEnricher_Propagation(t *testing.T) {
 	ctx.HeadersM["Authorization"] = "Bearer valid-token-12345"
 	ctx.On("GetString", "Authorization", "").Return("Bearer valid-token-12345")
 	ctx.On("Locals", "user", mock.AnythingOfType("*jwtware_test.MockAuthClaims")).Return(nil)
+	// The middleware also stores user for templates with default key "current_user"
+	ctx.On("Locals", "current_user", mock.AnythingOfType("*jwtware_test.MockAuthClaims")).Return(nil)
 
 	// Mock the Context() method to return an empty context initially
 	initialCtx := context.Background()
@@ -821,6 +843,8 @@ func TestJWTWare_ContextEnricher_NotCalled_When_Nil(t *testing.T) {
 	ctx.HeadersM["Authorization"] = "Bearer valid-token-67890"
 	ctx.On("GetString", "Authorization", "").Return("Bearer valid-token-67890")
 	ctx.On("Locals", "user", mock.AnythingOfType("*jwtware_test.MockAuthClaims")).Return(nil)
+	// The middleware also stores user for templates with default key "current_user"
+	ctx.On("Locals", "current_user", mock.AnythingOfType("*jwtware_test.MockAuthClaims")).Return(nil)
 
 	err := middleware(ctx)
 
@@ -870,6 +894,8 @@ func TestJWTWare_ContextEnricher_Called_With_Correct_Claims(t *testing.T) {
 	ctx.HeadersM["Authorization"] = "Bearer valid-owner-token"
 	ctx.On("GetString", "Authorization", "").Return("Bearer valid-owner-token")
 	ctx.On("Locals", "user", mock.AnythingOfType("*jwtware_test.MockAuthClaims")).Return(nil)
+	// The middleware also stores user for templates with default key "current_user"
+	ctx.On("Locals", "current_user", mock.AnythingOfType("*jwtware_test.MockAuthClaims")).Return(nil)
 	ctx.On("Context").Return(context.Background())
 	ctx.On("SetContext", mock.AnythingOfType("*context.valueCtx")).Return()
 
@@ -882,4 +908,183 @@ func TestJWTWare_ContextEnricher_Called_With_Correct_Claims(t *testing.T) {
 	assert.NotNil(t, receivedClaims, "ContextEnricher should have been called with claims")
 	assert.Equal(t, expectedSubject, receivedClaims.Subject(), "Claims should have correct subject")
 	assert.Equal(t, expectedRole, receivedClaims.Role(), "Claims should have correct role")
+}
+
+//--------------------------------------------------------------------------------------
+// Template User Tests
+//--------------------------------------------------------------------------------------
+
+func TestJWTWare_TemplateUser_WithUserProvider_MapOutput_UsesLocalsMerge(t *testing.T) {
+	// Create mock claims for successful validation
+	claims := NewMockAuthClaims("user-123", "user-123", "admin")
+	validator := NewMockTokenValidator().WithValidateFunc(func(tokenString string) (jwtware.AuthClaims, error) {
+		return claims, nil
+	})
+
+	// UserProvider that returns a map[string]any (should trigger LocalsMerge)
+	userProvider := func(claims jwtware.AuthClaims) (any, error) {
+		return map[string]any{
+			"id":       claims.UserID(),
+			"username": "admin_user",
+			"role":     claims.Role(),
+			"email":    "admin@example.com",
+		}, nil
+	}
+
+	cfg := jwtware.Config{
+		SigningKey: jwtware.SigningKey{
+			Key:    []byte("test-key"),
+			JWTAlg: "HS256",
+		},
+		TokenValidator: validator,
+		UserProvider:   userProvider,
+		SuccessHandler: func(ctx router.Context) error {
+			return ctx.Next()
+		},
+		ErrorHandler: func(ctx router.Context, err error) error {
+			return err
+		},
+	}
+
+	middleware := jwtware.New(cfg)
+
+	// Create mock context
+	ctx := router.NewMockContext()
+	ctx.HeadersM["Authorization"] = "Bearer valid-token-12345"
+	ctx.On("GetString", "Authorization", "").Return("Bearer valid-token-12345")
+	ctx.On("Locals", "user", mock.AnythingOfType("*jwtware_test.MockAuthClaims")).Return(nil)
+
+	// This is the key test: LocalsMerge should be called with map data
+	var mergedData map[string]any
+	ctx.On("LocalsMerge", "current_user", mock.AnythingOfType("map[string]interface {}")).Run(func(args mock.Arguments) {
+		mergedData = args.Get(1).(map[string]any)
+	}).Return(map[string]any{})
+
+	err := middleware(ctx)
+
+	assert.NoError(t, err, "Middleware should succeed with valid token")
+	assert.True(t, ctx.NextCalled, "Next() should be called for valid token")
+
+	// Verify that LocalsMerge was called with correct map data
+	ctx.AssertCalled(t, "LocalsMerge", "current_user", mock.AnythingOfType("map[string]interface {}"))
+	assert.NotNil(t, mergedData, "LocalsMerge should have received map data")
+	assert.Equal(t, "user-123", mergedData["id"], "Map should contain user ID")
+	assert.Equal(t, "admin_user", mergedData["username"], "Map should contain username")
+	assert.Equal(t, "admin", mergedData["role"], "Map should contain role")
+	assert.Equal(t, "admin@example.com", mergedData["email"], "Map should contain email")
+}
+
+func TestJWTWare_TemplateUser_WithUserProvider_NonMapOutput_UsesLocals(t *testing.T) {
+	// Create mock claims for successful validation
+	claims := NewMockAuthClaims("user-456", "user-456", "member")
+	validator := NewMockTokenValidator().WithValidateFunc(func(tokenString string) (jwtware.AuthClaims, error) {
+		return claims, nil
+	})
+
+	// UserProvider that returns a struct (not a map, should use Locals)
+	type User struct {
+		ID       string `json:"id"`
+		Username string `json:"username"`
+		Role     string `json:"role"`
+		Email    string `json:"email"`
+	}
+
+	userProvider := func(claims jwtware.AuthClaims) (any, error) {
+		return User{
+			ID:       claims.UserID(),
+			Username: "member_user",
+			Role:     claims.Role(),
+			Email:    "member@example.com",
+		}, nil
+	}
+
+	cfg := jwtware.Config{
+		SigningKey: jwtware.SigningKey{
+			Key:    []byte("test-key"),
+			JWTAlg: "HS256",
+		},
+		TokenValidator: validator,
+		UserProvider:   userProvider,
+		SuccessHandler: func(ctx router.Context) error {
+			return ctx.Next()
+		},
+		ErrorHandler: func(ctx router.Context, err error) error {
+			return err
+		},
+	}
+
+	middleware := jwtware.New(cfg)
+
+	// Create mock context
+	ctx := router.NewMockContext()
+	ctx.HeadersM["Authorization"] = "Bearer valid-token-67890"
+	ctx.On("GetString", "Authorization", "").Return("Bearer valid-token-67890")
+	ctx.On("Locals", "user", mock.AnythingOfType("*jwtware_test.MockAuthClaims")).Return(nil)
+
+	// This should use Locals (not LocalsMerge) since output is not a map
+	var storedUser User
+	ctx.On("Locals", "current_user", mock.AnythingOfType("jwtware_test.User")).Run(func(args mock.Arguments) {
+		storedUser = args.Get(1).(User)
+	}).Return(nil)
+
+	err := middleware(ctx)
+
+	assert.NoError(t, err, "Middleware should succeed with valid token")
+	assert.True(t, ctx.NextCalled, "Next() should be called for valid token")
+
+	// Verify that Locals was called with struct data (not LocalsMerge)
+	ctx.AssertCalled(t, "Locals", "current_user", mock.AnythingOfType("jwtware_test.User"))
+	ctx.AssertNotCalled(t, "LocalsMerge", mock.Anything, mock.Anything)
+	assert.Equal(t, "user-456", storedUser.ID, "User struct should contain correct ID")
+	assert.Equal(t, "member_user", storedUser.Username, "User struct should contain correct username")
+	assert.Equal(t, "member", storedUser.Role, "User struct should contain correct role")
+	assert.Equal(t, "member@example.com", storedUser.Email, "User struct should contain correct email")
+}
+
+func TestJWTWare_TemplateUser_DefaultKey_IsCurrentUser(t *testing.T) {
+	// Create mock claims for successful validation
+	claims := NewMockAuthClaims("user-999", "user-999", "guest")
+	validator := NewMockTokenValidator().WithValidateFunc(func(tokenString string) (jwtware.AuthClaims, error) {
+		return claims, nil
+	})
+
+	cfg := jwtware.Config{
+		SigningKey: jwtware.SigningKey{
+			Key:    []byte("test-key"),
+			JWTAlg: "HS256",
+		},
+		TokenValidator: validator,
+		// No TemplateUserKey specified, should default to "current_user"
+		SuccessHandler: func(ctx router.Context) error {
+			return ctx.Next()
+		},
+		ErrorHandler: func(ctx router.Context, err error) error {
+			return err
+		},
+	}
+
+	middleware := jwtware.New(cfg)
+
+	// Create mock context
+	ctx := router.NewMockContext()
+	ctx.HeadersM["Authorization"] = "Bearer valid-guest-token"
+	ctx.On("GetString", "Authorization", "").Return("Bearer valid-guest-token")
+	ctx.On("Locals", "user", mock.AnythingOfType("*jwtware_test.MockAuthClaims")).Return(nil)
+
+	// Should use default "current_user" key with claims directly (no UserProvider)
+	var storedClaims jwtware.AuthClaims
+	ctx.On("Locals", "current_user", mock.AnythingOfType("*jwtware_test.MockAuthClaims")).Run(func(args mock.Arguments) {
+		storedClaims = args.Get(1).(jwtware.AuthClaims)
+	}).Return(nil)
+
+	err := middleware(ctx)
+
+	assert.NoError(t, err, "Middleware should succeed with valid token")
+	assert.True(t, ctx.NextCalled, "Next() should be called for valid token")
+
+	// Verify that template user was stored under "current_user" key
+	ctx.AssertCalled(t, "Locals", "current_user", mock.AnythingOfType("*jwtware_test.MockAuthClaims"))
+	assert.NotNil(t, storedClaims, "Claims should be stored as template user")
+	assert.Equal(t, "user-999", storedClaims.Subject(), "Template user should have correct subject")
+	assert.Equal(t, "guest", storedClaims.Role(), "Template user should have correct role")
 }

--- a/mocks_test.go
+++ b/mocks_test.go
@@ -124,6 +124,31 @@ func (m *MockAuthenticator) IdentityFromSession(ctx context.Context, session aut
 	return args.Get(0).(auth.Identity), args.Error(1)
 }
 
+func (m *MockAuthenticator) TokenService() auth.TokenService {
+	args := m.Called()
+	return args.Get(0).(auth.TokenService)
+}
+
+// ////////////////////////////////////////////////////////////////////
+// MockTokenService implements auth.TokenService
+// ////////////////////////////////////////////////////////////////////
+type MockTokenService struct {
+	mock.Mock
+}
+
+func (m *MockTokenService) Generate(identity auth.Identity, resourceRoles map[string]string) (string, error) {
+	args := m.Called(identity, resourceRoles)
+	return args.String(0), args.Error(1)
+}
+
+func (m *MockTokenService) Validate(tokenString string) (auth.AuthClaims, error) {
+	args := m.Called(tokenString)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(auth.AuthClaims), args.Error(1)
+}
+
 // ////////////////////////////////////////////////////////////////////
 // MockLoginPayload implements auth.LoginPayload
 // ////////////////////////////////////////////////////////////////////

--- a/template_helpers_test.go
+++ b/template_helpers_test.go
@@ -615,8 +615,8 @@ func TestTemplateHelpersWithRouter(t *testing.T) {
 		{
 			name: "should extract user with default key",
 			setupCtx: func() router.Context {
-				ctx := newMockRouterContext()
-				ctx.Locals("current_user", user)
+				ctx := router.NewMockContext()
+				ctx.LocalsMock["current_user"] = user
 				return ctx
 			},
 			userKey:  "",
@@ -625,8 +625,8 @@ func TestTemplateHelpersWithRouter(t *testing.T) {
 		{
 			name: "should extract user with custom key",
 			setupCtx: func() router.Context {
-				ctx := newMockRouterContext()
-				ctx.Locals("template_user", user)
+				ctx := router.NewMockContext()
+				ctx.LocalsMock["template_user"] = user
 				return ctx
 			},
 			userKey:  "template_user",
@@ -635,7 +635,7 @@ func TestTemplateHelpersWithRouter(t *testing.T) {
 		{
 			name: "should return helpers without user when not in context",
 			setupCtx: func() router.Context {
-				return newMockRouterContext()
+				return router.NewMockContext()
 			},
 			userKey:  "current_user",
 			wantUser: false,
@@ -643,12 +643,12 @@ func TestTemplateHelpersWithRouter(t *testing.T) {
 		{
 			name: "should work with AuthClaims as user",
 			setupCtx: func() router.Context {
-				ctx := newMockRouterContext()
+				ctx := router.NewMockContext()
 				claims := &JWTClaims{
 					UID:      "user123",
 					UserRole: "admin",
 				}
-				ctx.Locals("current_user", claims)
+				ctx.LocalsMock["current_user"] = claims
 				return ctx
 			},
 			userKey:  "",
@@ -702,8 +702,8 @@ func TestGetTemplateUser(t *testing.T) {
 		{
 			name: "should return user with default key",
 			setupCtx: func() router.Context {
-				ctx := newMockRouterContext()
-				ctx.Locals("current_user", user)
+				ctx := router.NewMockContext()
+				ctx.LocalsMock["current_user"] = user
 				return ctx
 			},
 			userKey:  "",
@@ -713,8 +713,8 @@ func TestGetTemplateUser(t *testing.T) {
 		{
 			name: "should return user with custom key",
 			setupCtx: func() router.Context {
-				ctx := newMockRouterContext()
-				ctx.Locals("my_user", user)
+				ctx := router.NewMockContext()
+				ctx.LocalsMock["my_user"] = user
 				return ctx
 			},
 			userKey:  "my_user",
@@ -724,7 +724,7 @@ func TestGetTemplateUser(t *testing.T) {
 		{
 			name: "should return false when user not found",
 			setupCtx: func() router.Context {
-				return newMockRouterContext()
+				return router.NewMockContext()
 			},
 			userKey:  "current_user",
 			wantUser: nil,
@@ -733,8 +733,8 @@ func TestGetTemplateUser(t *testing.T) {
 		{
 			name: "should return false when user is nil",
 			setupCtx: func() router.Context {
-				ctx := newMockRouterContext()
-				ctx.Locals("current_user", nil)
+				ctx := router.NewMockContext()
+				ctx.LocalsMock["current_user"] = nil
 				return ctx
 			},
 			userKey:  "",
@@ -767,8 +767,8 @@ func TestTemplateIntegrationWorkflow(t *testing.T) {
 	}
 
 	// Create mock context as middleware would
-	ctx := newMockRouterContext()
-	ctx.Locals("current_user", user)
+	ctx := router.NewMockContext()
+	ctx.LocalsMock["current_user"] = user
 
 	// Extract user using helper function
 	templateUser, ok := GetTemplateUser(ctx, "current_user")

--- a/types.go
+++ b/types.go
@@ -64,6 +64,7 @@ type Authenticator interface {
 	Impersonate(ctx context.Context, identifier string) (string, error)
 	SessionFromToken(token string) (Session, error)
 	IdentityFromSession(ctx context.Context, session Session) (Identity, error)
+	TokenService() TokenService
 }
 
 type LoginPayload interface {


### PR DESCRIPTION
This PR exposes a TokenService function so we can use the core token service manager in other packages to do i.e. websocket authentication that matches our HTTP authentication so users can share sessions.